### PR TITLE
specify execution times, support `#[should_panic]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,74 @@
 extern crate proc_macro;
 extern crate syn;
+
 use proc_macro::TokenStream;
 use quote::quote;
+use syn::{Lit, Meta, MetaNameValue, NestedMeta, ItemFn};
 
+struct FlakyTestArgs {
+  times: usize,
+}
+
+impl Default for FlakyTestArgs {
+  fn default() -> Self {
+    FlakyTestArgs { times: 3 }
+  }
+}
+
+impl syn::parse::Parse for FlakyTestArgs {
+  fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+    if input.is_empty() {
+      return Ok(FlakyTestArgs::default());
+    }
+
+    let nested: NestedMeta = input.parse()?;
+
+    match nested {
+      NestedMeta::Lit(Lit::Int(lit_int)) => {
+        let times = lit_int.base10_parse::<usize>()?;
+        Ok(FlakyTestArgs { times })
+      }
+      NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit: Lit::Int(lit_int), .. })) => {
+        if path.is_ident("times") {
+          let times = lit_int.base10_parse::<usize>()?;
+          Ok(FlakyTestArgs { times })
+        } else {
+          Err(syn::Error::new_spanned(path, "expected `times`"))
+        }
+      }
+      _ => Err(syn::Error::new_spanned(nested, "expected `times = INT` or `INT`")),
+    }
+  }
+}
+
+/// A flaky test will be run multiple times until it passes.
+///
+/// # Example
+/// ```rust
+/// use flaky_test::flaky_test;
+///
+/// #[flaky_test]
+/// fn test_default() {
+///  println!("should pass");
+/// }
+///
+/// #[flaky_test(5)]
+/// fn usage_with_args() {
+///   println!("should pass");
+/// }
+///
+/// #[flaky_test(times = 5)]
+/// fn usage_with_named_args() {
+///   println!("should pass");
+/// }
+/// ```
 #[proc_macro_attribute]
-pub fn flaky_test(_attr: TokenStream, input: TokenStream) -> TokenStream {
-  let input_fn = syn::parse_macro_input!(input as syn::ItemFn);
+pub fn flaky_test(attr: TokenStream, input: TokenStream) -> TokenStream {
+  let args = syn::parse_macro_input!(attr as FlakyTestArgs);
+  let input_fn = syn::parse_macro_input!(input as ItemFn);
   let name = input_fn.sig.ident.clone();
   let attrs = input_fn.attrs.clone();
+  let times = args.times;
 
   TokenStream::from(quote! {
     #[test]
@@ -15,7 +76,7 @@ pub fn flaky_test(_attr: TokenStream, input: TokenStream) -> TokenStream {
     fn #name() {
       #input_fn
 
-      for i in 0..3 {
+      for i in 0..#times {
         println!("flaky_test retry {}", i);
         let r = std::panic::catch_unwind(|| {
           #name();
@@ -23,7 +84,7 @@ pub fn flaky_test(_attr: TokenStream, input: TokenStream) -> TokenStream {
         if r.is_ok() {
           return;
         }
-        if i == 2 {
+        if i == #times - 1 {
           std::panic::resume_unwind(r.unwrap_err());
         }
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,11 @@ use quote::quote;
 pub fn flaky_test(_attr: TokenStream, input: TokenStream) -> TokenStream {
   let input_fn = syn::parse_macro_input!(input as syn::ItemFn);
   let name = input_fn.sig.ident.clone();
+  let attrs = input_fn.attrs.clone();
+
   TokenStream::from(quote! {
     #[test]
+    #(#attrs)*
     fn #name() {
       #input_fn
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,8 +16,38 @@ fn fail_first_two_times() {
   assert_eq!(3, C.load(Ordering::SeqCst));
 }
 
+#[flaky_test(5)]
+fn fail_first_four_times() {
+  static C: AtomicUsize = AtomicUsize::new(0);
+  if C.fetch_add(1, Ordering::SeqCst) < 4 {
+    panic!("flaky");
+  }
+  assert_eq!(5, C.load(Ordering::SeqCst));
+}
+
+#[flaky_test(times = 10)]
+fn fail_first_nine_times() {
+  static C: AtomicUsize = AtomicUsize::new(0);
+  if C.fetch_add(1, Ordering::SeqCst) < 9 {
+    panic!("flaky");
+  }
+  assert_eq!(10, C.load(Ordering::SeqCst));
+}
+
 #[flaky_test]
 #[should_panic]
 fn fail_three_times() {
+  assert!(false);
+}
+
+#[flaky_test(5)]
+#[should_panic]
+fn fail_five_times() {
+  assert!(false);
+}
+
+#[flaky_test(times = 10)]
+#[should_panic]
+fn fail_ten_times() {
   assert!(false);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,10 +16,8 @@ fn fail_first_two_times() {
   assert_eq!(3, C.load(Ordering::SeqCst));
 }
 
-/* TODO(ry) should_panic doesn't seem to work
 #[flaky_test]
 #[should_panic]
 fn fail_three_times() {
   assert!(false);
 }
-*/


### PR DESCRIPTION
Closes #1, defaults to `3`

```rust
#[flaky_test]
fn test_default() {
  println!("should pass");
}

#[flaky_test(5)]
fn usage_with_args() {
  println!("should pass");
}

#[flaky_test(times = 5)]
fn usage_with_named_args() {
  println!("should pass");
}

#[flaky_test]
#[should_panic]
fn test_default() {
  panic!("this is a terrible mistake!");
}
```